### PR TITLE
'Sanitized' characters are no longer removed but escaped with a backslas...

### DIFF
--- a/src/TomLingham/Searchy/SearchDrivers/BaseSearchDriver.php
+++ b/src/TomLingham/Searchy/SearchDrivers/BaseSearchDriver.php
@@ -113,7 +113,7 @@ abstract class BaseSearchDriver implements SearchDriverInterface {
 	 */
 	private function sanitize( $searchString )
 	{
-		return preg_replace(\Config::get('searchy::sanitizeRegEx'), '', $searchString );
+		return preg_replace(\Config::get('searchy::sanitizeRegEx'), '\\\$0', $searchString );
 	}
 
 }


### PR DESCRIPTION
Simply removing characters is problematic because searches containing those characters will not find the correct results. In this PR I have updated the sanitize() function to escape the characters instead.