### PR TITLE
possibility of choosing columns

### DIFF
--- a/src/TomLingham/Searchy/SearchDrivers/BaseSearchDriver.php
+++ b/src/TomLingham/Searchy/SearchDrivers/BaseSearchDriver.php
@@ -41,6 +41,8 @@ abstract class BaseSearchDriver implements SearchDriverInterface {
 	public function columns($columns)
 	{
 		$this->columns = $columns;
+		
+		return $this;
 	}
 
 	/**

--- a/src/TomLingham/Searchy/SearchDrivers/BaseSearchDriver.php
+++ b/src/TomLingham/Searchy/SearchDrivers/BaseSearchDriver.php
@@ -22,6 +22,11 @@ abstract class BaseSearchDriver implements SearchDriverInterface {
 	 * @var null
 	 */
 	protected $table;
+	
+	/**
+	 * @var
+	 */
+	protected $columns = "*";
 
 	/**
 	 * @param null $table
@@ -32,20 +37,25 @@ abstract class BaseSearchDriver implements SearchDriverInterface {
 		$this->searchFields = $searchFields;
 		$this->table = $table;
 	}
+	
+	public function columns($columns)
+	{
+		$this->columns = $columns;
+	}
 
 	/**
 	 * @param $searchString
 	 * @return \Illuminate\Database\Query\Builder|mixed|static
 	 * @throws \Whoops\Example\Exception
 	 */
-	public function query( $searchString, $columns = "*")
+	public function query($searchString)
 	{
 
 		if(\Config::get('searchy::sanitize'))
 			$this->searchString = $this->sanitize($searchString);
 
 		$results = \DB::table($this->table)
-			->select($columns)
+			->select($this->columns)
 			->addSelect($this->buildSelectQuery( $this->searchFields ))
 			->orderBy(\Config::get('searchy::fieldName'), 'desc')
 			->having(\Config::get('searchy::fieldName'),'>', 0);

--- a/src/TomLingham/Searchy/SearchDrivers/BaseSearchDriver.php
+++ b/src/TomLingham/Searchy/SearchDrivers/BaseSearchDriver.php
@@ -38,14 +38,14 @@ abstract class BaseSearchDriver implements SearchDriverInterface {
 	 * @return \Illuminate\Database\Query\Builder|mixed|static
 	 * @throws \Whoops\Example\Exception
 	 */
-	public function query( $searchString )
+	public function query( $searchString, $columns = "*")
 	{
 
 		if(\Config::get('searchy::sanitize'))
 			$this->searchString = $this->sanitize($searchString);
 
 		$results = \DB::table($this->table)
-			->select('*')
+			->select($columns)
 			->addSelect($this->buildSelectQuery( $this->searchFields ))
 			->orderBy(\Config::get('searchy::fieldName'), 'desc')
 			->having(\Config::get('searchy::fieldName'),'>', 0);


### PR DESCRIPTION
Adding _columns()_ method by which you can select the columns and improve performance. Example:
```php
Searchy::search('products')->fields('name')->columns('id')->query($term)->lists('id')
```