### PR TITLE
Phpunit changes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ composer.phar
 composer.lock
 .DS_Store
 .idea
+phpunit.xml

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -11,7 +11,7 @@
          syntaxCheck="false"
 >
     <testsuites>
-        <testsuite name="Package Test Suite">
+        <testsuite name="Laravel Searchy Test Suite">
             <directory suffix=".php">./tests/</directory>
         </testsuite>
     </testsuites>


### PR DESCRIPTION
Having `.dist` means that you can write a test suite without affecting the distribution version.