### PR TITLE
Allow table.column as field

### DIFF
--- a/src/SearchDrivers/BaseSearchDriver.php
+++ b/src/SearchDrivers/BaseSearchDriver.php
@@ -158,8 +158,10 @@ abstract class BaseSearchDriver implements SearchDriverInterface
      * @param $name
      * @return string
      */
-    protected function sanitizeColumnName( $name ){
-        $name = trim($name, '` ');
+    protected function sanitizeColumnName($name)
+    {
+        $name = str_replace('.', '`.`', trim($name, '` '));
+
         return "`${name}`";
     }
 


### PR DESCRIPTION
This issue was introduced in 7c840af.

Providing a field as a column with table will treat the whole field as one column currently, because of the escaping.
```php
Searchy::users('users.name', 'addresses.name')->query('test')->getQuery()->join('addresses', 'users.id', '=', 'addresses.user_id')->get()
```
Will throw `Illuminate\Database\QueryException with message 'SQLSTATE[42S22]: Column not found: 1054 Unknown column 'users.name' in 'field list'`.