### PR TITLE
fix: convert levenshtein distance into relevance

### DIFF
--- a/src/Matchers/LevenshteinMatcher.php
+++ b/src/Matchers/LevenshteinMatcher.php
@@ -19,6 +19,6 @@ class LevenshteinMatcher extends BaseMatcher
      */
     public function buildQueryString($column, $searchString)
     {
-        return "levenshtein($column, '$searchString')";
+        return "FLOOR(((255 - levenshtein($column, '$searchString')) / 255) * 100)";
     }
 }


### PR DESCRIPTION
Levenshtein's return value has been implemented as a "relevance", when in actual fact what's being returned from the function is the distance from string A to B, for example:

levenshtein('FooBar', 'Foo') == 3

As there are three characters difference between the two.

I've added some code to convert the distance into a 0 -> 100 based relevance value.