### PR TITLE
Fix search query with quotes by replacing trim function to substr.

### DIFF
--- a/src/SearchDrivers/BaseSearchDriver.php
+++ b/src/SearchDrivers/BaseSearchDriver.php
@@ -72,7 +72,7 @@ abstract class BaseSearchDriver implements SearchDriverInterface
      */
     public function query($searchString)
     {
-        $this->searchString = trim(\DB::connection()->getPdo()->quote($searchString), "'");
+        $this->searchString = substr(substr(\DB::connection()->getPdo()->quote($searchString), 1), 0, -1);
 
         return $this;
     }


### PR DESCRIPTION
Need to remove only first and last quote. Because if you type something like ```id='``` PDO::quote replace it by ```'id=\''``` and trim replace it by ```id=\``` as result we will have sql syntax error!