### PR TITLE
Drop PHP 5.0 support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,21 +1,14 @@
 language: php
 
 php:
-  - 5.5.9
-  - 5.5
-  - 5.6
   - 7.0
-  - hhvm
+  - 7.1
+  - 7.2
 
 sudo: false
 
 install:
-  - travis_retry composer install --no-interaction --prefer-source
+  - travis_retry composer install --no-interaction
 
 script:
-  - if [ "$TRAVIS_PHP_VERSION" != "5.5.9" ] && [ "$TRAVIS_PHP_VERSION" != "5.5" ] && [ "$TRAVIS_PHP_VERSION" != "5.6" ]; then vendor/bin/phpunit; fi
-  - if [ "$TRAVIS_PHP_VERSION" == "5.5.9" ] || [ "$TRAVIS_PHP_VERSION" == "5.5" ] || [ "$TRAVIS_PHP_VERSION" == "5.6" ]; then vendor/bin/phpunit --coverage-clover build/logs/clover.xml; fi
-
-after_script:
-  - if [ "$TRAVIS_PHP_VERSION" == "5.5.9" ] || [ "$TRAVIS_PHP_VERSION" == "5.5" ] || [ "$TRAVIS_PHP_VERSION" == "5.6" ]; then wget https://scrutinizer-ci.com/ocular.phar; fi
-  - if [ "$TRAVIS_PHP_VERSION" == "5.5.9" ] || [ "$TRAVIS_PHP_VERSION" == "5.5" ] || [ "$TRAVIS_PHP_VERSION" == "5.6" ]; then php ocular.phar code-coverage:upload --format=php-clover build/logs/clover.xml; fi
+  - vendor/bin/phpunit

--- a/composer.json
+++ b/composer.json
@@ -10,7 +10,7 @@
         }
     ],
     "require": {
-        "php": "^5.5.9 || >=7.0",
+        "php": "^7.0",
         "illuminate/support": "5.1.* || 5.2.* || 5.3.* || 5.4.*"
     },
     "require-dev" :{

--- a/composer.json
+++ b/composer.json
@@ -14,9 +14,9 @@
         "illuminate/support": "5.1.* || 5.2.* || 5.3.* || 5.4.*"
     },
     "require-dev" :{
-        "graham-campbell/testbench": "^3.1",
-        "mockery/mockery": "^0.9.4",
-        "phpunit/phpunit": "^4.8 || ^5.0"
+        "graham-campbell/testbench": "^4.0",
+        "mockery/mockery": "dev-master#c90a17247147543081e4d00f46911e422b49e583",
+        "phpunit/phpunit": "^6.3"
     },
     "autoload": {
         "psr-4": {


### PR DESCRIPTION
Dropped PHP 5.* and HHVM support. This fixes failing tests in #78.