### PR TITLE
Add Laravel 5.5 support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,17 +5,13 @@ php:
   - 5.5
   - 5.6
   - 7.0
-  - hhvm
+  - 7.1
+  - 7.2
 
 sudo: false
 
 install:
-  - travis_retry composer install --no-interaction --prefer-source
-
+  - travis_retry composer install --no-interaction
+  
 script:
-  - if [ "$TRAVIS_PHP_VERSION" != "5.5.9" ] && [ "$TRAVIS_PHP_VERSION" != "5.5" ] && [ "$TRAVIS_PHP_VERSION" != "5.6" ]; then vendor/bin/phpunit; fi
-  - if [ "$TRAVIS_PHP_VERSION" == "5.5.9" ] || [ "$TRAVIS_PHP_VERSION" == "5.5" ] || [ "$TRAVIS_PHP_VERSION" == "5.6" ]; then vendor/bin/phpunit --coverage-clover build/logs/clover.xml; fi
-
-after_script:
-  - if [ "$TRAVIS_PHP_VERSION" == "5.5.9" ] || [ "$TRAVIS_PHP_VERSION" == "5.5" ] || [ "$TRAVIS_PHP_VERSION" == "5.6" ]; then wget https://scrutinizer-ci.com/ocular.phar; fi
-  - if [ "$TRAVIS_PHP_VERSION" == "5.5.9" ] || [ "$TRAVIS_PHP_VERSION" == "5.5" ] || [ "$TRAVIS_PHP_VERSION" == "5.6" ]; then php ocular.phar code-coverage:upload --format=php-clover build/logs/clover.xml; fi
+  - vendor/bin/phpunit

--- a/composer.json
+++ b/composer.json
@@ -10,13 +10,12 @@
         }
     ],
     "require": {
-        "php": "^5.5.9 || >=7.0",
-        "illuminate/support": "5.1.* || 5.2.* || 5.3.* || 5.4.*"
+        "php": "^5.5.9 || ^7.0",
+        "illuminate/support": "5.1.* || 5.2.* || 5.3.* || 5.4.* || 5.5.*"
     },
-    "require-dev" :{
-        "graham-campbell/testbench": "^3.1",
-        "mockery/mockery": "^0.9.4",
-        "phpunit/phpunit": "^4.8 || ^5.0"
+    "require-dev": {
+        "graham-campbell/testbench": "^3.4 || ^4.0",
+        "phpunit/phpunit": "^4.8 || ^5.7 || ^6.3"
     },
     "autoload": {
         "psr-4": {
@@ -30,6 +29,19 @@
     },
     "config": {
         "preferred-install": "dist"
+    },
+    "extra": {
+        "branch-alias": {
+            "dev-master": "3.0-dev"
+        },
+        "laravel": {
+            "providers": [
+                "TomLingham\\Searchy\\SearchyServiceProvider"
+            ],
+            "aliases": {
+                "Searchy": "TomLingham\\Searchy\\Facades\\Searchy"
+            }
+        }
     },
     "minimum-stability": "dev",
     "prefer-stable": true


### PR DESCRIPTION
This pull request replace #78 and #79 based on feedback.
- Added support for Laravel 5.5
- Added tests for PHP version 7.1 and 7.2
- Removed tests for HHVM

This should be good to merge into the 3.0 release since it doesn't break anything. This could alternatively be released in a new minor release.